### PR TITLE
Leader can now update video ID, required restructuring

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -14,13 +14,11 @@ function App() {
   const [leader, setLeader] = useState(false);
   const [sessionID, setSessionID] = useState(null);
   const [videoID, setVideoID] = useState(null);
-  const [action, setAction] = useState('join');
 
   const createSession = (vidID, session, leaderbool) => {
     setVideoID(vidID);
     setSessionID(session);
     setLeader(leaderbool);
-    setAction('create');
   };
   return (
     <Router>
@@ -41,7 +39,6 @@ function App() {
                   leader={leader}
                   sessionID={sessionID}
                   videoID={videoID}
-                  action={action}
                 />
               )}
             />

--- a/client/src/components/session/CreateSession.js
+++ b/client/src/components/session/CreateSession.js
@@ -4,11 +4,9 @@ import { uuid } from 'uuidv4';
 import { useHistory } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlay } from '@fortawesome/free-solid-svg-icons';
-import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import Welcome from '../welcome/welcome';
-
+import { handleYouTubeUrl } from '../../linkHandler';
 import './createSession.scss';
-import { toast } from 'react-toastify';
 
 const CreateSession = (props) => {
   const isTabletOrMobileDevice = useMediaQuery({
@@ -16,30 +14,13 @@ const CreateSession = (props) => {
   });
   const history = useHistory();
   const [url, setUrl] = useState('');
-  const notify = () =>
-    toast(
-      <div>
-        <FontAwesomeIcon icon={faExclamationTriangle} />
-        &nbsp; Invalid Link!
-      </div>
-    );
 
   const sessionID = uuid().slice(0, 6);
   const handleSubmit = (evt) => {
     evt.preventDefault();
-    var videoID = youtubeParser(url);
-    if (!videoID) {
-      notify();
-      return;
-    }
+    const videoID = handleYouTubeUrl(url);
     props.session(videoID, sessionID, true);
     history.push('/watch/leader');
-  };
-
-  const youtubeParser = (url) => {
-    var regExp = /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#&?]*).*/;
-    var match = url.match(regExp);
-    return match && match[7].length === 11 ? match[7] : false;
   };
 
   return (
@@ -53,7 +34,7 @@ const CreateSession = (props) => {
         <div className='input-container'>
           <form className='input-form' onSubmit={handleSubmit}>
             <input
-              placeholder='Paste a YouTube link '
+              placeholder='Paste a YouTube link'
               className='input-field'
               type='text'
               value={url}

--- a/client/src/components/session/Session.js
+++ b/client/src/components/session/Session.js
@@ -1,14 +1,19 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useHistory } from 'react-router-dom';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPlay } from '@fortawesome/free-solid-svg-icons';
 import Video from '../video/Video';
 import ShareLink from './ShareLink';
+import { handleYouTubeUrl } from '../../linkHandler';
 
 const Session = (props) => {
   const history = useHistory();
-  const url = 'ws://localhost:5000/';
-  const socket = new WebSocket(url);
+  const serverAddress = 'ws://localhost:5000/';
+  const socket = new WebSocket(serverAddress);
   let sessID = props.sessionID;
+
+  const [url, setUrl] = useState('');
 
   let { sessionID } = useParams();
   if (!sessID) {
@@ -20,13 +25,28 @@ const Session = (props) => {
       socket.send(
         JSON.stringify({
           event: 'session',
-          action: props.action,
+          action: props.leader ? 'create' : 'join',
           sessionID: sessID,
           videoID: props.videoID,
         })
       );
     };
-  });
+    // eslint-disable-next-line
+  }, []);
+
+  const handleSubmit = (evt) => {
+    evt.preventDefault();
+    const videoID = handleYouTubeUrl(url);
+    socket.send(
+      JSON.stringify({
+        event: 'session',
+        action: 'update',
+        sessionID: sessID,
+        videoID: videoID,
+      })
+    );
+  };
+
   if (sessionID === 'leader' && !props.leader) {
     history.push('/');
   }
@@ -39,6 +59,23 @@ const Session = (props) => {
         socket={socket}
       />
       {props.leader && <ShareLink link={props.sessionID} />}
+      {props.leader && (
+        <div className='input-container'>
+          <form className='input-form' onSubmit={handleSubmit}>
+            <input
+              placeholder='Paste a new YouTube link'
+              className='input-field'
+              type='text'
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+            />
+            <button className='input-button' type='Submit'>
+              <FontAwesomeIcon icon={faPlay} />
+            </button>
+          </form>
+          <br/>
+        </div>
+      )}
     </div>
   );
 };

--- a/client/src/components/session/ShareLink.js
+++ b/client/src/components/session/ShareLink.js
@@ -27,7 +27,7 @@ export default function CopyExample(props) {
       <form className='input-form'>
         <input
           className='input-field'
-          readonly
+          readOnly
           ref={textAreaRef}
           value={text}
         />

--- a/client/src/components/video/Video.js
+++ b/client/src/components/video/Video.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { toast } from 'react-toastify';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faUserFriends } from '@fortawesome/free-solid-svg-icons';
@@ -18,17 +18,21 @@ const Video = (props) => {
   const [videoID, setVideoID] = useState(props.videoID);
 
   const loadVideo = () => {
-    player = new window.YT.Player('player', {
-      videoId: videoID,
-      playerVars: {
-        mute: 1,
-        autoplay: 0,
-      },
-      events: {
-        onReady: onPlayerReady,
-        onStateChange: onStateChange,
-      },
-    });
+    if (!player) {
+      player = new window.YT.Player('player', {
+        videoId: videoID,
+        playerVars: {
+          mute: 1,
+          autoplay: 0,
+        },
+        events: {
+          onReady: onPlayerReady,
+          onStateChange: onStateChange,
+        },
+      });
+    } else {
+      player.loadVideoById(videoID);
+    }
   };
 
   const join = (data) => {
@@ -41,6 +45,7 @@ const Video = (props) => {
       if (data.event === 'sync') updateVideo(data);
       if (data.event === 'join') join(data);
       if (data.event === 'users' && props.leader) notify();
+      if (data.event === 'newVideo') setVideoID(data.videoID);
     });
     if (videoID !== null) {
       if (!window.YT) {
@@ -53,7 +58,8 @@ const Video = (props) => {
         firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
       } else loadVideo();
     }
-  });
+    // eslint-disable-next-line
+  }, [videoID]);
 
   const updateVideo = (data) => {
     let videoStatus = player.getPlayerState();

--- a/client/src/linkHandler.js
+++ b/client/src/linkHandler.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+import { toast } from 'react-toastify';
+
+function notifyLinkInvalid() {
+  toast(
+    <div>
+      <FontAwesomeIcon icon={faExclamationTriangle} />
+      &nbsp; Invalid Link!
+    </div>
+  );
+}
+
+function validateYouTubeUrl(url) {
+  var regExp = /^.*((youtu.be\/)|(v\/)|(\/u\/\w\/)|(embed\/)|(watch\?))\??v?=?([^#&?]*).*/;
+  var match = url.match(regExp);
+  return match && match[7].length === 11 ? match[7] : false;
+};
+
+export function handleYouTubeUrl(url) {
+  const videoID = validateYouTubeUrl(url);
+  if (!videoID) {
+    notifyLinkInvalid();
+    return;
+  }
+  return videoID;
+}

--- a/server/server.js
+++ b/server/server.js
@@ -87,6 +87,7 @@ const handleSessionEvent = (data, ws) => {
   let action = data.action;
   if (action === 'create') createSession(data, ws);
   else if (action === 'join') joinSession(data, ws);
+  else if (action === 'update') updateSession(data, ws);
 };
 
 const createSession = (data, ws) => {
@@ -95,4 +96,20 @@ const createSession = (data, ws) => {
     users: [{ ws: ws }],
     videoID: data.videoID,
   });
+};
+
+const updateSession = (data, ws) => {
+  let session = sessionById(data.sessionID);
+
+  if (session) {
+    session.videoID = data.videoID;
+    brodcastMessage(
+      {
+        event: 'newVideo',
+        videoID: session.videoID
+      },
+      session.users,
+      ws
+    );
+  }
 };


### PR DESCRIPTION
I've been working on this on/off ever since I emailed @filahf asking if this was open for the taking. I think I've got it working pretty well, but please clone and verify that it all *actually* works.

I'll attempt to summarize all the changes within, hopefully not forgetting anything:

1. Separated YouTube URL handling functions into a linkHandler.js so I could reuse that code in both CreateSession and Video.
2. Made `useEffect` in CreateSession and Video to not fire on each render, as I noticed a significant number of extra messages being sent to the server, and I think interfered with my changes. This was my first time working with React Hooks and I don't like it. I feel some of these components are substantial enough to be class components, but it wasn't *really* worth changing right now. Crossing fingers this didn't break anything.
3. Got rid of the `action` state in App. I felt it didn't fit in well into the new paradigm with video updates, and because in my opinion, it didn't feel like a good "state" to track, as it's only used occasionally. In my opinion, the server doesn't need this same value tracked in sessions either; it feels very confusing. But I didn't want to change the latter at this time. @filahf, feel free to disagree with me here! :)
4. Added the new feature. The leader sees a new input box to update the video for everyone. I restricted this to the leader because it felt appropriate, but can be expanded easily, I think. The new message to the server is fired when this new form is  submitted. After a lot of consideration and moving code around, I figured the broadcast was best handled in Video along with other video events, as it was the easiest to update the video ID in the YouTube player in that component. This way, all users, including the leader, get their video updated at the same time.

I feel the whole app is slightly finnicky, and sessions seem to drop very frequently in my day-to-day use. I didn't come across an obvious root cause, so that still happens. I also came across an error where the `player` variable in Video is unassigned for the leader in some circumstances and the app throws errors when someone else in the session syncs their video state. But I don't have it 100% isolated and couldn't fix. I hope that doesn't interfere with the new feature in your testing!

I made some assumptions, both about the UX and naming practices (variable and function names, web socket events), that I thought made sense given your existing code. @filahf, please feel free to take over from here and restructure or rename things as you see fit!